### PR TITLE
URLの組み立てをURLQueryItemとURLComponentsを用いる方法に変更

### DIFF
--- a/GourmetSearch/ApiManager/GetApiManager.swift
+++ b/GourmetSearch/ApiManager/GetApiManager.swift
@@ -15,9 +15,17 @@ class GetApiManager {
     
     // API通信
     func onGetResponse(latitude: Double, longitude: Double ,range: Int) {
-        guard let url = URL(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=\(key)&lat=\(latitude)&lng=\(longitude)&range=\(range)&count=100&format=json") else {
-            return
-        }
+        var baseUrl = URLComponents(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/")
+        baseUrl?.queryItems = [
+            URLQueryItem(name: "key", value: key),
+            URLQueryItem(name: "lat", value: String(latitude)),
+            URLQueryItem(name: "lng", value: String(longitude)),
+            URLQueryItem(name: "range", value: String(range)),
+            URLQueryItem(name: "count", value: "100"),
+            URLQueryItem(name: "format", value: "json"),
+        ]
+        
+        guard let url = baseUrl?.url else { return}
         
         let task: URLSessionTask = URLSession.shared.dataTask(with: url, completionHandler: { [self](data, response, error) in
             

--- a/GourmetSearch/View/Base.lproj/Main.storyboard
+++ b/GourmetSearch/View/Base.lproj/Main.storyboard
@@ -239,7 +239,7 @@
                                     <fragment content="住所">
                                         <attributes>
                                             <color key="NSColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <font key="NSFont" size="17" name=".HiraKakuInterface-W3"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>


### PR DESCRIPTION
## URLの組み立てロジックを修正
OS 標準機能 `URLQueryItem` と `URLComponents`を活用